### PR TITLE
Value of capabilities should be a string

### DIFF
--- a/db/services.php
+++ b/db/services.php
@@ -65,7 +65,7 @@ $functions = array(
                 'description' => 'Delete answers of user.',    //human readable description of the web service function
                 'type' => 'write',                  //database rights of the web service function (read, write)
                 'ajax' => true,        // is the service available to 'internal' ajax calls.
-                'capabilities' => array(),   // capabilities required by the function.
+                'capabilities' => '',   // capabilities required by the function. String made of comma separated values
         ),
         'mod_groupformation_exclude_users' => array(         //web service function name
                 'classname' => 'mod_groupformation_external',
@@ -77,6 +77,6 @@ $functions = array(
                 'description' => 'Exclude users.',    //human readable description of the web service function
                 'type' => 'write',                  //database rights of the web service function (read, write)
                 'ajax' => true,        // is the service available to 'internal' ajax calls.
-                'capabilities' => array(),   // capabilities required by the function.
+                'capabilities' => '',   // capabilities required by the function.
         ),
 );


### PR DESCRIPTION
Hello,
Here is a fix for the value of 'capabilities' key in '$functions' array of db/services.php. This value should be a string (comma separeted if multiple values). Using 'capabilities' => array(),  is causig failure at the installation time on moodle 4.1.

The error commes from lib/upgradelib.php because in the method external_update_descriptions, the value of 'capabilities' is expected to be a string (that will be stored in the table {external_functions} ).

Would you like to pull the fix please?

Here is the kind of errors produced  with this array value at the installation time on moodle 4.1:

Default exception handler: Exception - mysqli::real_escape_string(): Argument #1 ($string) must be of type string, array given Debug:
Error code: generalexceptionmessage
* line 1145 of /lib/dml/mysqli_native_moodle_database.php: TypeError thrown
* line 1145 of /lib/dml/mysqli_native_moodle_database.php: call to mysqli->real_escape_string()
* line 1357 of /lib/dml/mysqli_native_moodle_database.php: call to mysqli_native_moodle_database->emulate_bound_params()
* line 1408 of /lib/dml/mysqli_native_moodle_database.php: call to mysqli_native_moodle_database->insert_record_raw()
* line 1313 of /lib/upgradelib.php: call to mysqli_native_moodle_database->insert_record()
* line 643 of /lib/upgradelib.php: call to external_update_descriptions()
* line 923 of /lib/upgradelib.php: call to upgrade_component_updated()
* line 677 of /lib/upgradelib.php: call to upgrade_plugins_modules()
* line 1953 of /lib/upgradelib.php: call to upgrade_plugins()
* line 202 of /admin/cli/upgrade.php: call to upgrade_noncore()


Thanks so much.